### PR TITLE
COMP: Fix macOS CMP0011 warning in SlicerExtensionCPackBundleFixup CM…

### DIFF
--- a/CMake/BundleUtilitiesWithRPath.cmake
+++ b/CMake/BundleUtilitiesWithRPath.cmake
@@ -230,6 +230,7 @@
 # (and possibly others) found in:
 #
 cmake_policy(SET CMP0009 NEW)
+cmake_policy(SET CMP0011 NEW)
 
 get_filename_component(BundleUtilities_cmake_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include("${BundleUtilities_cmake_dir}/GetPrerequisitesWithRPath.cmake")


### PR DESCRIPTION
…ake module

The following warning was reported when directly invoking the module
from the command line.

For example:

$ cmake \
  -DCMAKE_INSTALL_PREFIX:PATH=/path/to/SlicerVMTK-build/inner-build/_CPack_Packages/Darwin/TGZ/26720-macosx-amd64-SlicerVMTK-git0efbf09-2017-12-18 \
  -P SlicerExtensionBundle/SlicerExtensionCPackBundleFixup.cmake

CMake Warning (dev) in /path/to/Slicer/CMake/BundleUtilitiesWithRPath.cmake:
  Policy CMP0011 is not set: Included scripts do automatic cmake_policy PUSH
  and POP.  Run "cmake --help-policy CMP0011" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  The included script

    /path/to/Slicer/CMake/BundleUtilitiesWithRPath.cmake

  affects policy settings.  CMake is implying the NO_POLICY_SCOPE option for
  compatibility, so the effects are applied to the including context.
Call Stack (most recent call first):
  SlicerExtensionBundle/SlicerExtensionCPackBundleFixup.cmake:2 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

git-svn-id: http://svn.slicer.org/Slicer4/trunk@26721 3bd1e089-480b-0410-8dfb-8563597acbee